### PR TITLE
feat: Implement team pages and player recent performance

### DIFF
--- a/mlb_app/templates/mlb_app/base.html
+++ b/mlb_app/templates/mlb_app/base.html
@@ -69,6 +69,8 @@
                            href="{% url 'mlb_app:games' %}">比賽</a>
                         <a class="text-[#0d141c] text-sm font-medium leading-normal hover:text-blue-600 transition-colors {% if 'players' in request.resolver_match.url_name %}text-blue-600 font-bold{% endif %}" 
                            href="{% url 'mlb_app:search_players' %}">球員</a>
+                        <a class="text-[#0d141c] text-sm font-medium leading-normal hover:text-blue-600 transition-colors {% if request.resolver_match.url_name == 'teams_list' or request.resolver_match.url_name == 'team_detail' or request.resolver_match.url_name == 'team_roster' %}text-blue-600 font-bold{% endif %}"
+                           href="{% url 'mlb_app:teams_list' %}">球隊</a>
                         <a class="text-[#0d141c] text-sm font-medium leading-normal hover:text-blue-600 transition-colors {% if request.resolver_match.url_name == 'about' %}text-blue-600 font-bold{% endif %}" 
                            href="{% url 'mlb_app:about' %}">關於</a>
                         <a class="text-[#0d141c] text-sm font-medium leading-normal hover:text-blue-600 transition-colors {% if request.resolver_match.url_name == 'help' %}text-blue-600 font-bold{% endif %}" 

--- a/mlb_app/templates/mlb_app/player_detail.html
+++ b/mlb_app/templates/mlb_app/player_detail.html
@@ -175,13 +175,66 @@
                 <!-- Recent Performance -->
                 <div class="mt-6">
                     <h3 class="text-lg font-bold text-[#0d141c] mb-4">近期表現</h3>
-                    <div class="bg-gray-50 rounded-lg p-6 text-center">
-                        {% if recent_performance_available %}
-                            <p class="text-[#49739c]">載入最新比賽表現數據中...</p>
-                        {% else %}
-                            <p class="text-[#49739c]">近期比賽表現數據即將推出。</p>
-                        {% endif %}
-                    </div>
+                    {% if recent_performance_available and recent_game_logs %}
+                        <div class="bg-gray-50 rounded-lg p-1 overflow-x-auto">
+                            <table class="w-full text-sm">
+                                <thead class="bg-gray-100">
+                                    <tr class="border-b border-[#e7edf4]">
+                                        <th class="text-left py-3 px-4 text-[#0d141c] font-medium">日期</th>
+                                        <th class="text-left py-3 px-4 text-[#0d141c] font-medium">對手</th>
+                                        {% if quick_stats_type == 'pitching' %}
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">IP</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">H</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">R</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">ER</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">BB</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">SO</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">ERA</th>
+                                        {% else %} {# Default to Hitter stats #}
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">AB</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">R</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">H</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">RBI</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">HR</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">BB</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">SO</th>
+                                            <th class="text-right py-3 px-4 text-[#0d141c] font-medium">AVG</th>
+                                        {% endif %}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for log in recent_game_logs %}
+                                    <tr class="border-b border-[#e7edf4] hover:bg-gray-100">
+                                        <td class="py-3 px-4 text-[#0d141c] font-medium">{{ log.game_date|date:"Y-m-d" }}</td>
+                                        <td class="py-3 px-4 text-[#49739c]">{{ log.opponent_team_abbr|default:"N/A" }}</td>
+                                        {% if quick_stats_type == 'pitching' %}
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.innings_pitched|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.hits_allowed|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.runs_allowed|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.earned_runs|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.walks_issued|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.strikeouts_thrown|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#0d141c] font-medium">{{ log.era|floatformat:2|default:"-" }}</td>
+                                        {% else %} {# Default to Hitter stats #}
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.at_bats|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.runs_scored|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.hits|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.rbi|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.home_runs|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.walks|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#49739c]">{{ log.strikeouts|default:"-" }}</td>
+                                            <td class="py-3 px-4 text-right text-[#0d141c] font-medium">{{ log.batting_average|floatformat:3|default:"-" }}</td>
+                                        {% endif %}
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% else %}
+                        <div class="bg-gray-50 rounded-lg p-6 text-center">
+                            <p class="text-[#49739c]">沒有最近的比賽記錄。</p>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
             

--- a/mlb_app/templates/mlb_app/team_detail.html
+++ b/mlb_app/templates/mlb_app/team_detail.html
@@ -1,0 +1,129 @@
+{% extends 'mlb_app/base.html' %}
+{% load static %}
+
+{% block title %}{{ page_title }} - MLB 統計查詢系統{% endblock %}
+
+{% block description %}查看 {{ team.name }} 球隊的詳細資訊，包括球隊歷史、球場、聯盟和分區等。{% endblock %}
+
+{% block content %}
+<div class="p-4">
+    <!-- Team Header -->
+    <div class="bg-gradient-to-r from-blue-700 to-indigo-600 rounded-xl text-white p-8 mb-8 shadow-xl">
+        <div class="container mx-auto">
+            <div class="flex flex-col md:flex-row items-center gap-6">
+                <div class="flex-shrink-0">
+                    {# Placeholder for team logo - could use an SVG or an image if available #}
+                    <div class="w-24 h-24 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor" viewBox="0 0 256 256" class="text-white">
+                            <path d="M160,16H96A16,16,0,0,0,80,32V224a16,16,0,0,0,16,16h64a16,16,0,0,0,16-16V32A16,16,0,0,0,160,16Zm0,208H96V32h64ZM48,208a16,16,0,0,1-16-16V64A16,16,0,0,1,48,48H72V64H48V192H72v16ZM208,48H184V64h24V192H184v16h24a16,16,0,0,0,16-16V64A16,16,0,0,0,208,48Z"></path>
+                        </svg>
+                    </div>
+                </div>
+                <div class="flex-1 text-center md:text-left">
+                    <h1 class="text-4xl font-bold mb-2">{{ team.name }}</h1>
+                    {% if team.abbreviation %}
+                        <p class="text-xl opacity-90">({{ team.abbreviation }})</p>
+                    {% endif %}
+                </div>
+                <div class="mt-4 md:mt-0">
+                    <a href="{% url 'mlb_app:team_roster' team_id=team.mlb_id %}"
+                       class="px-6 py-3 bg-white text-blue-700 rounded-lg hover:bg-gray-100 transition-colors font-semibold text-lg shadow-md hover:shadow-lg">
+                        查看球隊名單
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Team Details Grid -->
+    <div class="container mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Basic Info Card -->
+            <div class="bg-white rounded-xl border border-gray-200 shadow-lg p-6">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-6 border-b pb-3">基本資訊</h2>
+                <div class="space-y-4 text-gray-700">
+                    <div class="flex justify-between">
+                        <span class="font-medium">球隊ID (MLB ID):</span>
+                        <span class="text-gray-900">{{ team.mlb_id }}</span>
+                    </div>
+                    <div class="flex justify-between">
+                        <span class="font-medium">球隊全名:</span>
+                        <span class="text-gray-900">{{ team.name }}</span>
+                    </div>
+                    {% if team.team_code %}
+                    <div class="flex justify-between">
+                        <span class="font-medium">球隊代碼:</span>
+                        <span class="text-gray-900">{{ team.team_code }}</span>
+                    </div>
+                    {% endif %}
+                    {% if team.abbreviation %}
+                    <div class="flex justify-between">
+                        <span class="font-medium">縮寫:</span>
+                        <span class="text-gray-900">{{ team.abbreviation }}</span>
+                    </div>
+                    {% endif %}
+                    {% if team.first_year_of_play %}
+                    <div class="flex justify-between">
+                        <span class="font-medium">創立年份:</span>
+                        <span class="text-gray-900">{{ team.first_year_of_play }}</span>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <!-- League & Division Card -->
+            <div class="bg-white rounded-xl border border-gray-200 shadow-lg p-6">
+                <h2 class="text-2xl font-semibold text-gray-800 mb-6 border-b pb-3">聯盟與分區</h2>
+                <div class="space-y-4 text-gray-700">
+                    {% if team.league_name %}
+                    <div class="flex justify-between">
+                        <span class="font-medium">聯盟:</span>
+                        <span class="text-gray-900">{{ team.league_name }}</span>
+                    </div>
+                    {% else %}
+                    <div class="flex justify-between">
+                        <span class="font-medium">聯盟:</span>
+                        <span class="text-gray-500">N/A</span>
+                    </div>
+                    {% endif %}
+                    {% if team.division_name %}
+                    <div class="flex justify-between">
+                        <span class="font-medium">分區:</span>
+                        <span class="text-gray-900">{{ team.division_name }}</span>
+                    </div>
+                    {% else %}
+                    <div class="flex justify-between">
+                        <span class="font-medium">分區:</span>
+                        <span class="text-gray-500">N/A</span>
+                    </div>
+                    {% endif %}
+                     <div class="flex justify-between">
+                        <span class="font-medium">運動項目:</span>
+                        <span class="text-gray-900">{{ team.sport_name|default:"棒球" }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Venue Info Card -->
+        {% if team.venue_name %}
+        <div class="bg-white rounded-xl border border-gray-200 shadow-lg p-6 mt-6">
+            <h2 class="text-2xl font-semibold text-gray-800 mb-6 border-b pb-3">球場資訊</h2>
+            <div class="space-y-4 text-gray-700">
+                <div class="flex justify-between">
+                    <span class="font-medium">球場名稱:</span>
+                    <span class="text-gray-900">{{ team.venue_name }}</span>
+                </div>
+                {% if team.location_city %}
+                <div class="flex justify-between">
+                    <span class="font-medium">城市:</span>
+                    <span class="text-gray-900">{{ team.location_city }}</span>
+                </div>
+                {% endif %}
+                {# Add more venue details if available in model, e.g., capacity, address #}
+            </div>
+        </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/mlb_app/templates/mlb_app/team_roster.html
+++ b/mlb_app/templates/mlb_app/team_roster.html
@@ -1,0 +1,75 @@
+{% extends 'mlb_app/base.html' %}
+{% load static %}
+
+{% block title %}{{ page_title }} - MLB 統計查詢系統{% endblock %}
+
+{% block description %}查看 {{ team.name }} 球隊的完整球員名單，包括球員位置和連結到他們的詳細統計資料。{% endblock %}
+
+{% block content %}
+<div class="p-4">
+    <!-- Page Header -->
+    <div class="bg-gradient-to-r from-gray-700 to-gray-800 text-white p-6 rounded-xl shadow-lg mb-8">
+        <div class="container mx-auto">
+            <h1 class="text-3xl font-bold mb-1">{{ team.name }}</h1>
+            <p class="text-xl opacity-90">{{ page_title }}</p>
+            <div class="mt-4">
+                <a href="{% url 'mlb_app:team_detail' team_id=team.mlb_id %}"
+                   class="inline-block bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-lg transition-colors text-sm">
+                    &laquo; 返回球隊詳細資訊
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Roster Table -->
+    <div class="container mx-auto">
+        {% if players %}
+            <div class="mb-4 text-sm text-gray-600">
+                共 {{ total_players }} 位球員。
+            </div>
+            <div class="bg-white rounded-xl border border-gray-200 shadow-md overflow-hidden">
+                <div class="overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead class="bg-gray-100 border-b border-gray-200">
+                            <tr>
+                                <th class="text-left py-3 px-5 text-gray-700 font-semibold">姓名</th>
+                                <th class="text-left py-3 px-5 text-gray-700 font-semibold">位置</th>
+                                <th class="text-right py-3 px-5 text-gray-700 font-semibold">MLB ID</th>
+                                <th class="text-center py-3 px-5 text-gray-700 font-semibold">狀態</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for player in players %}
+                            <tr class="border-b border-gray-200 hover:bg-gray-50 transition-colors">
+                                <td class="py-3 px-5 text-gray-800">
+                                    <a href="{% url 'mlb_app:player_detail' player_id=player.mlb_id %}" class="text-blue-600 hover:text-blue-800 hover:underline font-medium">
+                                        {{ player.full_name|default:"N/A" }}
+                                    </a>
+                                </td>
+                                <td class="py-3 px-5 text-gray-600">{{ player.primary_position|default:"N/A" }}</td>
+                                <td class="py-3 px-5 text-right text-gray-600">{{ player.mlb_id|default:"N/A" }}</td>
+                                <td class="py-3 px-5 text-center">
+                                    {% if player.active %}
+                                        <span class="px-2 py-1 text-xs font-semibold text-green-700 bg-green-100 rounded-full">現役</span>
+                                    {% else %}
+                                        <span class="px-2 py-1 text-xs font-semibold text-red-700 bg-red-100 rounded-full">非現役</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        {% else %}
+            <div class="text-center py-10 bg-white rounded-xl border border-gray-200 shadow-md">
+                <svg xmlns="http://www.w3.org/2000/svg" width="56" height="56" fill="currentColor" class="text-gray-400 mx-auto mb-3" viewBox="0 0 256 256">
+                    <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24ZM74.08,197.5a64,64,0,0,1,107.84,0,87.83,87.83,0,0,1-107.84,0ZM96,120a32,32,0,1,1,32,32A32,32,0,0,1,96,120Zm97.76,66.41a79.66,79.66,0,0,0-36.06-28.75,48,48,0,1,0-59.4,0A79.66,79.66,0,0,0,56.24,186.41,88,88,0,1,1,193.76,186.41Z"></path>
+                </svg>
+                <h2 class="text-xl font-semibold text-gray-700 mb-2">該球隊目前沒有球員資料</h2>
+                <p class="text-gray-500">請確認球隊資料是否已同步，或稍後再試。</p>
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/mlb_app/templates/mlb_app/teams_list.html
+++ b/mlb_app/templates/mlb_app/teams_list.html
@@ -1,0 +1,77 @@
+{% extends 'mlb_app/base.html' %}
+{% load static %}
+
+{% block title %}{{ page_title }} - MLB 統計查詢系統{% endblock %}
+
+{% block description %}查看所有 MLB 球隊的列表。點擊球隊名稱以獲取更多詳細資訊。{% endblock %}
+
+{% block content %}
+<div class="p-4">
+    <!-- Page Header -->
+    <div class="bg-gradient-to-r from-blue-600 to-green-500 text-white p-6 rounded-xl shadow-lg mb-8">
+        <div class="container mx-auto">
+            <h1 class="text-3xl font-bold mb-2">{{ page_title }}</h1>
+            <p class="text-lg opacity-90">探索所有美國職棒大聯盟的球隊。</p>
+        </div>
+    </div>
+
+    <!-- Teams Grid -->
+    <div class="container mx-auto">
+        {% if teams %}
+            <div class="mb-4 text-sm text-gray-600">
+                共找到 {{ total_teams }} 支球隊。
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {% for team in teams %}
+                <div class="bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-lg transition-shadow duration-300">
+                    <div class="p-6">
+                        <h2 class="text-xl font-semibold text-blue-700 mb-2">
+                            <a href="{% url 'mlb_app:team_detail' team_id=team.mlb_id %}" class="hover:text-blue-500 hover:underline">
+                                {{ team.name }}
+                            </a>
+                        </h2>
+                        <div class="space-y-2 text-sm text-gray-600">
+                            <div class="flex items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="text-gray-400 mr-2 shrink-0" viewBox="0 0 256 256"><path d="M128,64a64,64,0,1,0,64,64A64.07,64.07,0,0,0,128,64Zm0,112a48,48,0,1,1,48-48A48.05,48.05,0,0,1,128,176Z"></path></svg>
+                                ID: {{ team.mlb_id|default:"N/A" }}
+                            </div>
+                            {% if team.abbreviation %}
+                            <div class="flex items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="text-gray-400 mr-2 shrink-0" viewBox="0 0 256 256"><path d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32ZM160,128H96V96h64Zm48,64H48V64H208V192Z"></path></svg>
+                                縮寫: {{ team.abbreviation }}
+                            </div>
+                            {% endif %}
+                            {% if team.venue_name %}
+                            <div class="flex items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="text-gray-400 mr-2 shrink-0" viewBox="0 0 256 256"><path d="M128,64a40,40,0,0,0-40,40c0,28.52,32.26,72.37,35.78,77.15a8,8,0,0,0,8.44,0C135.74,176.37,168,132.52,168,104A40,40,0,0,0,128,64Zm0,56a16,16,0,1,1,16-16A16,16,0,0,1,128,120Z"></path></svg>
+                                球場: {{ team.venue_name }}
+                            </div>
+                            {% endif %}
+                            {% if team.league_name %}
+                            <div class="flex items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="text-gray-400 mr-2 shrink-0" viewBox="0 0 256 256"><path d="M240,128a15.87,15.87,0,0,0-9.42-14.79l-72-32A16,16,0,0,0,144,96v16H112V96a16,16,0,0,0-14.58-15.21l-72,16A16,16,0,0,0,8,112v80a16,16,0,0,0,16,16H224a16,16,0,0,0,16-16Zm-16,64H24V118.17l64-14.22V192Zm0-85.17L160,98.61V192h64Z"></path></svg>
+                                聯盟: {{ team.league_name }} ({{ team.division_name|default:"N/A" }})
+                            </div>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="bg-gray-50 p-4 rounded-b-xl border-t border-gray-200">
+                         <a href="{% url 'mlb_app:team_detail' team_id=team.mlb_id %}" class="text-sm font-medium text-blue-600 hover:text-blue-800 transition-colors">
+                            查看詳情 &raquo;
+                        </a>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="text-center py-10">
+                <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="text-gray-400 mx-auto mb-4" viewBox="0 0 256 256">
+                    <path d="M160,16H96A16,16,0,0,0,80,32V224a16,16,0,0,0,16,16h64a16,16,0,0,0,16-16V32A16,16,0,0,0,160,16Zm0,208H96V32h64ZM48,208a16,16,0,0,1-16-16V64A16,16,0,0,1,48,48H72V64H48V192H72v16ZM208,48H184V64h24V192H184v16h24a16,16,0,0,0,16-16V64A16,16,0,0,0,208,48Z"></path>
+                </svg>
+                <h2 class="text-xl font-semibold text-gray-700 mb-2">目前沒有球隊資料</h2>
+                <p class="text-gray-500">請稍後再回來查看，或嘗試同步球隊數據。</p>
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/mlb_app/urls.py
+++ b/mlb_app/urls.py
@@ -119,6 +119,21 @@ urlpatterns = [
     # URL: /help/
     # 功能: 顯示使用說明和常見問題
     path('help/', views.help_page, name='help'),
+
+    # 球隊列表
+    # URL: /teams/
+    # 功能: 顯示所有球隊的列表
+    path('teams/', views.teams_list, name='teams_list'),
+
+    # 球隊詳細資訊
+    # URL: /teams/123/
+    # 功能: 顯示特定球隊的詳細資訊 (123 為 team_id, 即 mlb_id)
+    path('teams/<int:team_id>/', views.team_detail, name='team_detail'),
+
+    # 球隊球員名單
+    # URL: /teams/123/roster/
+    # 功能: 顯示特定球隊的球員名單
+    path('teams/<int:team_id>/roster/', views.team_roster, name='team_roster'),
 ]
 
 # URL 設計說明：


### PR DESCRIPTION
This commit completes several aspects of the project:

1.  **Player Recent Performance:**
    - The player detail page now displays a "Recent Performance" section.
    - It shows the player's last 5 game logs with relevant stats (H/AB, R, RBI for hitters; IP, H, ER, SO, BB for pitchers).

2.  **Team Functionality:**
    - **Team List Page (`/teams/`):** Displays all MLB teams in a grid format. Each team links to its detail page.
    - **Team Detail Page (`/teams/<team_id>/`):** Shows detailed information for a specific team, including name, city, league, division, and a link to the team roster.
    - **Team Roster Page (`/teams/<team_id>/roster/`):** Lists all players belonging to the selected team, with their position, MLB ID, and a link to their individual player detail page.

3.  **Navigation:**
    - A new "球隊" (Teams) link has been added to the main navigation bar, providing access to the team listing page.
    - The link includes active state highlighting for improved user experience.

These additions significantly enhance the application's feature set by providing comprehensive team information and more detailed player insights.