### PR TITLE
Fix ML_SETTINGS comment typo

### DIFF
--- a/mlb_project/settings.py
+++ b/mlb_project/settings.py
@@ -321,7 +321,7 @@ ML_SETTINGS = {
         'MODEL_UPDATE_INTERVAL_SECONDS': 3600,  # 1小時更新一次
         'CACHE_TIMEOUT': 1800,                  # 30分鐘快取
         'MAX_RECOMMENDATIONS': 8,               # 最大推薦數量
-        'MIN_SIMILARITY_THRESHOLD': 0.5,        # 最小相似度闾值
+        'MIN_SIMILARITY_THRESHOLD': 0.5,        # 最小相似度閾值
     },
     # 表現預測設定
     'PERFORMANCE_PREDICTION': {


### PR DESCRIPTION
## Summary
- correct comment typo for `MIN_SIMILARITY_THRESHOLD` in `settings.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684030a63e68832c8e7eaced479fed52