### PR TITLE
Fix player sync updated_at check

### DIFF
--- a/mlb_app/management/commands/sync_players.py
+++ b/mlb_app/management/commands/sync_players.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Any, Optional
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.utils import timezone
+from datetime import timedelta
 from django.core.cache import cache
 
 from mlb_app.models import Player, Team
@@ -331,7 +332,7 @@ class Command(BaseCommand):
             # 檢查是否需要更新
             if not force_update:
                 # 如果最近已更新過，跳過
-                if (timezone.now() - player.updated_at).hours < 24:
+                if timezone.now() - player.updated_at < timedelta(hours=24):
                     return False, False
             
             # 更新球員資訊


### PR DESCRIPTION
## Summary
- fix check for recently updated players in `sync_players`
- add missing `timedelta` import

## Testing
- `flake8 mlb_app/management/commands/sync_players.py` *(fails: many style errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684031151ff0832ca44ecc16263fa0ea