### PR TITLE
Fix syntax error in system health check command

### DIFF
--- a/mlb_app/management/commands/system_health_check.py
+++ b/mlb_app/management/commands/system_health_check.py
@@ -461,7 +461,7 @@ class Command(BaseCommand):
                 security_warnings.append('未啟用 XSS 過濾器')
             
             # 檢查中介軟體
-            middleware = getattr(settings, 'MIDDLEWARE', [])\n            
+            middleware = getattr(settings, 'MIDDLEWARE', [])
             security_middleware_found = any('SecurityMiddleware' in mw for mw in middleware)
             if not security_middleware_found:
                 security_warnings.append('未發現自定義安全中介軟體')


### PR DESCRIPTION
## Summary
- fix newline escape causing invalid syntax in `system_health_check` command

## Testing
- `pyflakes mlb_app`

------
https://chatgpt.com/codex/tasks/task_e_68402fd12e9c832ca51317dda59b6859