### PR TITLE
Add tests for validate_date_input

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,20 @@
+import os
+import django
+import pytest
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mlb_project.settings")
+django.setup()
+
+from mlb_app.security import InputValidator
+
+
+def test_validate_date_valid():
+    assert InputValidator.validate_date_input("2024-05-10") == "2024-05-10"
+
+
+def test_validate_date_invalid_format():
+    assert InputValidator.validate_date_input("05-10-2024") is None
+
+
+def test_validate_date_nonexistent():
+    assert InputValidator.validate_date_input("2024-02-30") is None


### PR DESCRIPTION
## Summary
- add pytest suite for security module
- ensure date validation handles valid, invalid format, and nonexistent dates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684035df83a4832caa18cbba442640ff